### PR TITLE
Add AssemblyResolver

### DIFF
--- a/DetailManager/DetailManager.vcxproj
+++ b/DetailManager/DetailManager.vcxproj
@@ -14,6 +14,7 @@
     <ProjectGuid>{D8C17B6C-5AFA-482D-86FD-D988D52E7584}</ProjectGuid>
     <RootNamespace>DetailManager</RootNamespace>
     <Keyword>Win32Proj</Keyword>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -22,12 +23,14 @@
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -56,11 +59,11 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;DETAILMANAGER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>
@@ -72,10 +75,10 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;DETAILMANAGER_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
-      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <ModuleDefinitionFile>exports.def</ModuleDefinitionFile>

--- a/DetailManager/source/dllmain.cpp
+++ b/DetailManager/source/dllmain.cpp
@@ -122,6 +122,7 @@ void WINAPI atsLoad()
     wchar_t detailmodules_txt_path[MAX_PATH];
 
     g_first_time = true;
+    System::AppDomain::CurrentDomain->AssemblyResolve += g_managed::resolve_event_handler;
 
     int ret;
     {
@@ -225,6 +226,8 @@ void WINAPI atsDispose()
 		}
         FreeLibrary(g_detailmodules[i].hm_dll);
     }
+
+    System::AppDomain::CurrentDomain->AssemblyResolve -= g_managed::resolve_event_handler;
 
     memset(g_detailmodules, 0, sizeof(ST_DETAILMODULE_ATS_DELEGATE_FUNC));
     g_num_of_detailmodules = 0;

--- a/DetailManager/source/dllmain.cpp
+++ b/DetailManager/source/dllmain.cpp
@@ -62,9 +62,9 @@ ref struct g_managed {
 #include <stdio.h>
 
 BOOL WINAPI DllMain(
-					HINSTANCE hinstDLL,  // DLL ���W���[���̃n���h��
-					DWORD fdwReason,     // �֐����Ăяo�����R
-					LPVOID lpvReserved   // �\��ς�
+					HINSTANCE hinstDLL,  // DLL モジュールのハンドル
+					DWORD fdwReason,     // 関数を呼び出す理由
+					LPVOID lpvReserved   // 予約済み
 					)
 {
 	switch (fdwReason)

--- a/DetailManager/source/dllmain.cpp
+++ b/DetailManager/source/dllmain.cpp
@@ -51,13 +51,20 @@ ATS_HANDLES g_handles[2];
 
 bool g_first_time;
 
+
+System::Reflection::Assembly^ customAssemblyResolver(System::Object^ obj, System::ResolveEventArgs^ args);
+
+ref struct g_managed {
+  static System::ResolveEventHandler^ resolve_event_handler = gcnew System::ResolveEventHandler(customAssemblyResolver);
+};
+
 #include <sys/stat.h>
 #include <stdio.h>
 
 BOOL WINAPI DllMain(
-					HINSTANCE hinstDLL,  // DLL ƒ‚ƒWƒ…[ƒ‹‚Ìƒnƒ“ƒhƒ‹
-					DWORD fdwReason,     // ŠÖ”‚ğŒÄ‚Ño‚·——R
-					LPVOID lpvReserved   // —\–ñÏ‚İ
+					HINSTANCE hinstDLL,  // DLL ï¿½ï¿½ï¿½Wï¿½ï¿½ï¿½[ï¿½ï¿½ï¿½Ìƒnï¿½ï¿½ï¿½hï¿½ï¿½
+					DWORD fdwReason,     // ï¿½Öï¿½ï¿½ï¿½ï¿½Ä‚Ñoï¿½ï¿½ï¿½ï¿½ï¿½R
+					LPVOID lpvReserved   // ï¿½\ï¿½ï¿½Ï‚ï¿½
 					)
 {
 	switch (fdwReason)

--- a/DetailManager/source/dllmain.cpp
+++ b/DetailManager/source/dllmain.cpp
@@ -91,6 +91,24 @@ BOOL WINAPI DllMain(
 	return true;
 }
 
+#pragma managed
+System::Reflection::Assembly^ customAssemblyResolver(System::Object^ obj, System::ResolveEventArgs^ args)
+{
+    System::Reflection::Assembly^ asmToRet = nullptr;
+    System::Reflection::AssemblyName^ asmName = gcnew System::Reflection::AssemblyName(args->Name);
+
+    if (args->RequestingAssembly == nullptr)
+        return nullptr;
+
+    System::String^ requestingAsmLocation = System::IO::Path::GetDirectoryName(args->RequestingAssembly->Location);
+    System::String^ dllPathToFind = System::IO::Path::Combine(requestingAsmLocation, asmName->Name + ".dll");
+
+    if (System::IO::File::Exists(dllPathToFind))
+        asmToRet = System::Reflection::Assembly::LoadFrom(dllPathToFind);
+
+    return asmToRet;
+}
+
 // Called when this plug-in is loaded
 void WINAPI atsLoad()
 {


### PR DESCRIPTION
## 概要

C#(CLR)を使用したプラグインをロードする際, プラグインの依存関係を解決する処理にてプラグインDLLと同じディレクトリからの探索も試行する処理を実装した

## 実行環境

- Windows11 (Build 22543.1000)
- Visual Studio Community 2022 Preview (Version 17.1.0 Preview 5.0)
- Microsoft (R) C/C++ Optimizing Compiler Version 19.31.31104 for x86
- Bve Trainsim Version 5.8.7554.391

## 修正の詳細

まず, 2aa7b707572216cac9ba3cb27d5262180ccb4602 にてC++/CLI機能を有効化した

https://github.com/TetsuOtter/TR.ATSPI.CSharpScript/blob/c7c02667f8c544d512721cae3aa22c74532ef49d/TR.ATSPI.CSharpScript/ATSPluginInterface.cs#L25-L46

次に, c60eb9602ea30155246e4ac6979d5be309987a73 にて, TR.ATSPI.CSharpScriptでの実装を参考にAssemblyResolverを実装した

## 備考

- C#で開発する場合も, 現状だとDllExportで各関数をExportさせる必要がある
- .NET Frameworkのバージョンをv4.8に指定しているが, これでもBVE5.8で正常に動作した.
- DetailManagerにx64対応が実装されていないため, BVE6では動作を確認していない