### PR TITLE
Add `#pragma unmanaged`

### DIFF
--- a/DetailManager/source/dllmain.cpp
+++ b/DetailManager/source/dllmain.cpp
@@ -61,6 +61,7 @@ ref struct g_managed {
 #include <sys/stat.h>
 #include <stdio.h>
 
+#pragma unmanaged
 BOOL WINAPI DllMain(
 					HINSTANCE hinstDLL,  // DLL モジュールのハンドル
 					DWORD fdwReason,     // 関数を呼び出す理由


### PR DESCRIPTION
DllMainがunmanagedであることを明示しないとC4747 Warningが出てしまうため

#2 に含め忘れていたもの